### PR TITLE
Agregar el registro y listado de coordinador en usuario CEPAT

### DIFF
--- a/src/app/pages/administrador/applicant-form/applicant-form.component.html
+++ b/src/app/pages/administrador/applicant-form/applicant-form.component.html
@@ -1,7 +1,7 @@
 <div class="card">
   <div class="card-header border-0 pt-6">
     <div class="card-title">
-      <h3>{{ isEdit ? 'Editar Solicitante' : 'Agregar Solicitante' }}</h3>
+      <h3>{{ isEdit ? 'Editar CEPAT' : 'Agregar CEPAT' }}</h3>
     </div>
     <div class="card-toolbar">
     </div>

--- a/src/app/pages/administrador/register/constants/registro-usuario.constant.ts
+++ b/src/app/pages/administrador/register/constants/registro-usuario.constant.ts
@@ -7,14 +7,7 @@ export interface RegistroCard {
 }
 
 export const REGISTROS_POR_ROL: { [key: string]: RegistroCard } = {
-  'coordinador': {
-    titulo: 'USER_REGISTER.COORDINATOR.TITLE',
-    descripcion: 'USER_REGISTER.COORDINATOR.DESCRIPTION',
-    color: 'sky',
-    icono: 'person_add',
-    ruta: '/administrador/coordinador/registro',
-  },
-  'solicitante': {
+  'cepat': {
     titulo: 'USER_REGISTER.GUEST.TITLE',
     descripcion: 'USER_REGISTER.GUEST.DESCRIPTION',
     color: 'peach',

--- a/src/app/pages/cepat/cepat-routing.module.ts
+++ b/src/app/pages/cepat/cepat-routing.module.ts
@@ -33,7 +33,15 @@ const routes: Routes = [
             },
             {
                 path: 'registro',
-                loadComponent: () => import('../administrador/register/register.component').then(m => m.RegisterComponent)
+                loadComponent: () => import('./register-cepat/register-cepat.component').then(m => m.RegisterCepatComponent)
+            },
+            {
+                path: 'coordinador/registro',
+                loadComponent: () => import('../administrador/coordinator-form/coordinator-form.component').then(m => m.CoordinatorFormComponent)
+            },
+            {
+                path: 'coordinador/list',
+                loadComponent: () => import('../administrador/coordinator-listing/coordinator-listing.component').then(m => m.CoordinatorListingComponent)
             },
             {
                 path: 'reportes',

--- a/src/app/pages/cepat/register-cepat/constants/registro-usuario.constant.ts
+++ b/src/app/pages/cepat/register-cepat/constants/registro-usuario.constant.ts
@@ -1,0 +1,18 @@
+export interface RegistroCard {
+  titulo: string;
+  descripcion: string;
+  ruta: string;
+  color: string;
+  icono: string;
+}
+
+export const REGISTROS_POR_CEPAT: { [key: string]: RegistroCard } = {
+  'coordinador': {
+    titulo: 'USER_REGISTER.COORDINATOR.TITLE',
+    descripcion: 'USER_REGISTER.COORDINATOR.DESCRIPTION',
+    color: 'sky',
+    icono: 'person_add',
+    ruta: '/cepat/coordinador/registro',
+  },
+};
+

--- a/src/app/pages/cepat/register-cepat/register-cepat.component.html
+++ b/src/app/pages/cepat/register-cepat/register-cepat.component.html
@@ -1,0 +1,19 @@
+<div class="registro-container">
+  <h2>{{ "USER_REGISTER.TITLE" | translate }}</h2>
+  <p>{{ "USER_REGISTER.DESCRIPTION" | translate }}</p>
+
+  <div class="card-grid">
+    <div
+      class="card registro-card"
+      *ngFor="let registro of registros"
+      [ngClass]="registro.color"
+      (click)="verRegistro(registro.ruta)"
+    >
+      <span class="material-icons icono-registro">{{ registro.icono }}</span>
+      <h3>{{ registro.titulo | translate }}</h3>
+      <p>{{ registro.descripcion | translate }}</p>
+
+      <button>{{ "USER_REGISTER.REGISTER" | translate }}</button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/cepat/register-cepat/register-cepat.component.scss
+++ b/src/app/pages/cepat/register-cepat/register-cepat.component.scss
@@ -1,0 +1,95 @@
+.registro-container {
+  padding: 2rem;
+  text-align: center;
+  background-color: #fefefe;
+
+  h2 {
+    margin-bottom: 2rem;
+    font-size: 2rem;
+    font-weight: 600;
+    color: #2c3e50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+
+    &::before {
+      content: "";
+    }
+  }
+  p {
+      font-size: 0.95rem;
+      margin-bottom: 1rem;
+      color: #555;
+    }
+
+  .card-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    justify-content: center;
+  }
+
+  .registro-card {
+    width: 260px;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.05);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    color: #2c3e50;
+    background-color: #fff;
+    border: 1px solid #ececec;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    mat-icon {
+      font-size: 40px;
+      margin-bottom: 10px;
+    }
+
+    h3 {
+      font-size: 1.2rem;
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+    }
+
+    p {
+      font-size: 0.95rem;
+      margin-bottom: 1rem;
+      color: #555;
+    }
+
+    button {
+      padding: 0.5rem 1rem;
+      font-weight: 600;
+      border: none;
+      border-radius: 8px;
+      background-color: rgba(255, 255, 255, 0.95);
+      color: #333;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+
+      &:hover {
+        background-color: #f2f2f2;
+      }
+    }
+
+    &:hover {
+      transform: translateY(-5px);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  .sky {
+  background-color: #d4e6f1;
+  }
+
+
+  .peach {
+  background-color: #fdebd3;
+  }
+
+}

--- a/src/app/pages/cepat/register-cepat/register-cepat.component.spec.ts
+++ b/src/app/pages/cepat/register-cepat/register-cepat.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegisterCepatComponent } from './register-cepat.component';
+
+describe('RegisterCepatComponent', () => {
+  let component: RegisterCepatComponent;
+  let fixture: ComponentFixture<RegisterCepatComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RegisterCepatComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RegisterCepatComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/cepat/register-cepat/register-cepat.component.ts
+++ b/src/app/pages/cepat/register-cepat/register-cepat.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SharedModule } from 'src/app/template/shared/shared.module';
+import {
+  RegistroCard,
+  REGISTROS_POR_CEPAT,
+} from './constants/registro-usuario.constant';
+import { Router, ActivatedRoute } from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-register-cepat',
+  standalone: true,
+  imports: [CommonModule, SharedModule, TranslateModule],
+  templateUrl: './register-cepat.component.html',
+  styleUrl: './register-cepat.component.scss',
+})
+export class RegisterCepatComponent {
+  registros: RegistroCard[] = [];
+
+  constructor(private router: Router, private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.registros = Object.values(REGISTROS_POR_CEPAT);
+  }
+
+  verRegistro(archivo: string): void {
+    this.router.navigate([archivo], { relativeTo: this.route });
+  }
+}

--- a/src/app/template/shared/menus.ts
+++ b/src/app/template/shared/menus.ts
@@ -32,12 +32,12 @@ export const ADMINISTRATOR_MENUS = [
     link: '/administrador/coordinadores',
     type: 'link'
   },
-  {
-    name: 'MENU.ADMIN.COORDINATORS',
-    icon: 'person',
-    link: '/administrador/solicitantes',
-    type: 'link'
-  },
+  // {
+  //   name: 'MENU.ADMIN.COORDINATORS',
+  //   icon: 'person',
+  //   link: '/administrador/solicitantes',
+  //   type: 'link'
+  // },
   {
     name: 'MENU.INTELECTUAL_PROPERTIES',
     type: 'separator',
@@ -243,6 +243,27 @@ export const CEPAT_MENUS = [
     icon: 'dashboard',
     link: '/cepat/dashboard',
     type: 'link',
+  },
+    {
+    name: 'MENU.REGISTERS',
+    icon: 'add',
+    type: 'separator'
+  },
+  {
+    name: 'MENU.USERS',
+    icon: 'person_add',
+    link: '/cepat/registro',
+    type: 'link',
+  },
+  {
+    name: 'MENU.USERS',
+    type: 'separator',
+  },
+  {
+    name: 'MENU.ADMIN.COORDINATORS',
+    icon: 'person',
+    link: '/cepat/coordinador/list',
+    type: 'link'
   },
   {
     name: 'MENU.REGISTERS',


### PR DESCRIPTION
El apartado de registro de coordinador existente actualmente dentro del rol de administrador debe de ser migrado al rol de CEPAT, ya que estos serán los encargados de los registros de coordinador con su respectivo listado.  