### PR TITLE
fix: Modificación del orden de columnas en registros IMPI e INDAUTOR

### DIFF
--- a/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
+++ b/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
@@ -219,6 +219,20 @@ export class ModeloUtilidadComponent implements OnInit, AfterViewInit, OnDestroy
       })),
       columns: [
         {
+          title: 'Número de expediente',
+          data: 'numeroExpediente',
+          render: (data) => {
+            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
+          },
+        },
+        {
+          title: 'Número de certificado',
+          data: 'numeroCertificado',
+          render: (data) => {
+            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
+          },
+        },
+        {
           title: this.translate.instant('TABLE.BRANCH'),
           data: 'rama',
           render: (data, type, full) => {
@@ -277,20 +291,6 @@ export class ModeloUtilidadComponent implements OnInit, AfterViewInit, OnDestroy
           data: 'fechaSolicitud',
           render: (data) => {
             return `<span class="fw-semibold text-gray-600">${moment(data).format('DD-MM-YYYY')}</span>`;
-          },
-        },
-        {
-          title: 'Número de expediente',
-          data: 'numeroExpediente',
-          render: (data) => {
-            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
-          },
-        },
-        {
-          title: 'Número de certificado',
-          data: 'numeroCertificado',
-          render: (data) => {
-            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
           },
         }
       ],

--- a/src/app/pages/comun/propiedad-intelectual/patente/patente.component.ts
+++ b/src/app/pages/comun/propiedad-intelectual/patente/patente.component.ts
@@ -332,6 +332,20 @@ export class PatenteComponent implements OnInit, AfterViewInit, OnDestroy {
       }),
       columns: [
         {
+          title: 'Número de expediente', // Nueva columna
+          data: 'numeroExpediente',
+          render: (data) => {
+            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
+          },
+        },
+        {
+          title: 'Número de título', // Nueva columna
+          data: 'numeroTitulo',
+          render: (data) => {
+            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
+          },
+        },
+        {
           title: this.translate.instant('TABLE.BRANCH'),
           data: 'rama',
           render: (data, type, full) => {
@@ -390,20 +404,6 @@ export class PatenteComponent implements OnInit, AfterViewInit, OnDestroy {
           data: 'fechaSolicitud',
           render: (data) => {
             return `<span class="fw-semibold text-gray-600">${moment(data).format('DD-MM-YYYY')}</span>`;
-          },
-        },
-        {
-          title: 'Número de expediente', // Nueva columna
-          data: 'numeroExpediente',
-          render: (data) => {
-            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
-          },
-        },
-        {
-          title: 'Número de título', // Nueva columna
-          data: 'numeroTitulo',
-          render: (data) => {
-            return `<span class="fw-semibold text-gray-600">${data || ''}</span>`;
           },
         }
       ],


### PR DESCRIPTION

### Descripción del trabajo realizado
- De acuerdo con las indicaciones del documento, primero se realizó la modificación del orden de las columnas Número de expediente y Número de título en registros IMPI, cabe mencionar, que no existe ninguna columna denominada Número de control, ya que esa se indicaba en el documento de indicaciones.
- Se realizó la modificación del orden de las columnas Número de expediente y Número de certificado en registros INDAUTOR, de igual manera, no existe una columna denominada Número de control.