### PR TITLE
Fix: tablero cuerpos académicos con datos reales, íconos y estructura

### DIFF
--- a/src/app/api/services/tableros.service.ts
+++ b/src/app/api/services/tableros.service.ts
@@ -47,6 +47,11 @@ export interface ProgramaEducativo {
   total_registros: number;
 }
 
+export interface CuerpoAcademico {
+  nombre_cuerpo_academico: string;
+  total_registros: number;
+}
+
 export interface Departamento {
   departamento_param: number;
   nombre_departamento: string;
@@ -70,6 +75,17 @@ export class TablerosService {
   getProgramasEducativos(): Observable<ProgramaEducativo[]> {
     return this.http.get<ProgramaEducativo[]>('/api/tableros/registros/por-programa/').pipe(
       catchError(() => {
+        return of([]);
+      })
+    );
+  }
+
+  getCuerposAcademicos(): Observable<CuerpoAcademico[]> {
+  return this.http
+    .get<CuerpoAcademico[]>('/api/tableros/registros/por-cuerpo-academico/')
+    .pipe(
+      catchError(error => {
+        console.error('Error en getCuerposAcademicos:', error);
         return of([]);
       })
     );

--- a/src/app/pages/coordinador/dashboard/dashboard.component.html
+++ b/src/app/pages/coordinador/dashboard/dashboard.component.html
@@ -3,11 +3,12 @@
   <div class="col-xl-6">
     <app-departamentos></app-departamentos>
   </div>
-  <!-- Tablero por Cuerpos Académicos -->
+<!-- Tablero por Cuerpos Académicos -->
   <div class="col-xl-6">
-    <app-cuerpos-academicos></app-cuerpos-academicos>
+    <app-cuerpos-academicos
+      [datos]="cuerposAcademicosDatos"
+    ></app-cuerpos-academicos>
   </div>
-</div>
 
 <div class="row g-5 g-xl-8">
   <!-- Tablero por Programas Educativos -->

--- a/src/app/pages/coordinador/dashboard/dashboard.component.ts
+++ b/src/app/pages/coordinador/dashboard/dashboard.component.ts
@@ -1,8 +1,10 @@
 import { ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
-import { TablerosService, CategoriaInvestigador, ProgramaEducativo } from 'src/app/api/services/tableros.service';
+import { TablerosService, CategoriaInvestigador, ProgramaEducativo, CuerpoAcademico } from 'src/app/api/services/tableros.service';
 import { getCSSVariableValue } from '../../../template/kt/_utils';
 import { TranslateService } from '@ngx-translate/core';
 import { ExportExcelService } from 'src/app/api/services/export-excel.service';
+
+
 
 @Component({
   selector: 'app-dashboard',
@@ -13,6 +15,8 @@ export class DashboardComponent implements OnInit {
   chartOptionsRound: any = {};
   selectedFilter: string = '1';
   programasEducativos: ProgramaEducativo[] = [];
+  cuerposAcademicosDatos: CuerpoAcademico[] = [];
+
 
   @Input() cssClass: string = '';
   @Input() chartSize: number = 70;
@@ -39,8 +43,23 @@ export class DashboardComponent implements OnInit {
     });
  }
 
+ private loadCuerposAcademicos(): void {
+  this.tablerosService.getCuerposAcademicos().subscribe({
+    next: (data: CuerpoAcademico[]) => {
+      this.cuerposAcademicosDatos = data;
+      this.cdRef.detectChanges();
+    },
+    error: (err) => {
+      console.error('Error al cargar cuerpos academicos', err);
+      this.cuerposAcademicosDatos = [];
+      this.cdRef.detectChanges();
+    }
+  });
+}
+
   ngOnInit(): void {
     this.loadProgramasEducativos();
+    this.loadCuerposAcademicos();
     // Lógica original
     this.chartOptions = this.getChartOptions(350);
     setTimeout(() => {

--- a/src/app/template/layout/components/cuerpos-academicos/cuerpos-academicos.component.ts
+++ b/src/app/template/layout/components/cuerpos-academicos/cuerpos-academicos.component.ts
@@ -1,7 +1,12 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 
-interface CuerpoAcademico {
-  icono?: string; // Ícono de Material Icons (opcional)
+interface CuerpoAcademicoAPI {
+  nombre_cuerpo_academico: string;
+  total_registros: number;
+}
+
+interface CuerpoAcademicoView {
+  icono?: string;    // Ícono de Material Icons (opcional)
   nombre: string;
   solicitudes: number;
 }
@@ -11,40 +16,82 @@ interface CuerpoAcademico {
   templateUrl: './cuerpos-academicos.component.html',
   styleUrl: './cuerpos-academicos.component.scss'
 })
-export class CuerposAcademicosComponent {
-  cuerposAcademicos = [
-  { icono: 'computer', nombre: 'Tecnologías de la Información', solicitudes: 847 },
-  { icono: 'functions', nombre: 'Matemáticas Aplicadas', solicitudes: 392 },
-  { icono: 'science', nombre: 'Química Analítica', solicitudes: 715 },
-  { icono: 'solar_power', nombre: 'Energías Renovables', solicitudes: 284 },
-  { icono: 'memory', nombre: 'Inteligencia Artificial', solicitudes: 663 },
-  { icono: 'eco', nombre: 'Ciencias Ambientales', solicitudes: 501 },
-  { icono: 'agriculture', nombre: 'Desarrollo Agroindustrial', solicitudes: 778 },
-  { icono: 'business_center', nombre: 'Gestión Empresarial', solicitudes: 319 },
-  { icono: 'biotech', nombre: 'Bioingeniería Aplicada', solicitudes: 645 },
-  { icono: 'apartment', nombre: 'Administración Moderna', solicitudes: 187 },
-  { icono: 'settings', nombre: 'Optimización de Sistemas de Producción de Bienes y Servicios', solicitudes: 926 },
-  { icono: 'developer_mode', nombre: 'Desarrollo de Aplicaciones Interdisciplinarias bajo Metodologías de Ingeniería de Software', solicitudes: 538 },
-  { icono: 'health_and_safety', nombre: 'Sistemas Mecatrónicos Aplicados al Sector Salud e Industrial', solicitudes: 472 },
-  { icono: 'water_drop', nombre: 'Ingeniería de Procesos Ambientales', solicitudes: 613 },
-  { icono: 'recycling', nombre: 'Ingeniería de Procesos para la Generación de Tecnología para la Innovación y el Aprovechamiento de Recursos Naturales', solicitudes: 289 },
-  { icono: 'hub', nombre: 'Ingeniería de Sistemas', solicitudes: 734 },
-  { icono: 'trending_up', nombre: 'Calidad y Gestión Inteligente', solicitudes: 401 },
-  { icono: 'engineering', nombre: 'Ingeniería Administrativa', solicitudes: 957 },
-  { icono: 'school', nombre: 'Investigación en los Sistemas de Tecnología y la Administración del Conocimiento en las Organizaciones', solicitudes: 523 },
-  { icono: 'language', nombre: 'Tecnologías Emergentes de la Web', solicitudes: 346 },
-  { icono: 'energy_savings_leaf', nombre: 'Ingeniería para la Sustentabilidad Energética de la Química', solicitudes: 688 },
-  { icono: 'code', nombre: 'Ingeniería de Software y Aplicaciones de la Computación', solicitudes: 219 }
-];
+export class CuerposAcademicosComponent implements OnChanges {
 
-  ngOnInit(): void {}
+  @Input() datos: CuerpoAcademicoAPI[] = [];
+
+  // Evento para que el padre dispare la descarga de Excel
+  @Output() exportExcel = new EventEmitter<void>();
+
+  cuerposAcademicos: CuerpoAcademicoView[] = [];
+
+  private iconMapping: { [key: string]: string } = {
+    // MAPEOS ANTERIORES 
+    'Tecnologías de la Información': 'computer',
+    'Matemáticas Aplicadas': 'functions',
+    'Química Analítica': 'science',
+    'Energías Renovables': 'solar_power',
+    'Inteligencia Artificial': 'memory',
+    'Ciencias Ambientales': 'eco',
+    'Desarrollo Agroindustrial': 'agriculture',
+    'Gestión Empresarial': 'business_center',
+    'Bioingeniería Aplicada': 'biotech',
+    'Administración Moderna': 'apartment',
+    'Optimización de Sistemas de Producción de Bienes y Servicios': 'settings',
+    'Desarrollo de Aplicaciones Interdisciplinarias bajo Metodologías de Ingeniería de Software': 'developer_mode',
+    'Sistemas Mecatrónicos Aplicados al Sector Salud e Industrial': 'health_and_safety',
+    'Ingeniería de Procesos Ambientales': 'water_drop',
+    'Ingeniería de Procesos para la Generación de Tecnología para la Innovación y el Aprovechamiento de Recursos Naturales': 'recycling',
+    'Ingeniería de Sistemas': 'hub',
+    'Calidad y Gestión Inteligente': 'trending_up',
+    'Ingeniería Administrativa': 'engineering',
+    'Investigación en los Sistemas de Tecnología y la Administración del Conocimiento en las Organizaciones': 'school',
+    'Tecnologías Emergentes de la Web': 'language',
+    'Ingeniería para la Sustentabilidad Energética de la Química': 'energy_savings_leaf',
+    'Ingeniería de Software y Aplicaciones de la Computación': 'code',
+
+    // NUEVOS: nombres reales que vienen del endpoint
+    'CA de Energía y Electrónica': 'solar_power',
+    'CA de Ingeniería Química': 'science',
+    'CA de Economía Social': 'diversity_3',
+    'CA de Ingeniería Administrativa': 'engineering',
+    'CA de Ciencia de Datos': 'storage',
+    'CA de Electrónica': 'memory',
+    'CA de Semiconductores': 'memory',
+    'CA Multidisciplinarios': 'hub',
+    'CA de Gestión Empresarial': 'business_center',
+    'CA de Informática y Computación': 'computer',
+    'CA de Sistemas Computacionales': 'computer',
+    'CA de Ingeniería Industrial': 'precision_manufacturing',
+    'CA de Mecánica': 'build',
+  };
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['datos']) {
+      this.mapeoDatos();
+    }
+  }
+
+  private mapeoDatos(): void {
+    this.cuerposAcademicos = (this.datos || []).map((item) => {
+      const nombre = item.nombre_cuerpo_academico;
+      return {
+        nombre,
+        solicitudes: item.total_registros,
+        icono: this.getIcono(nombre),
+      };
+    });
+  }
+
+  private getIcono(nombre: string): string {
+    return this.iconMapping[nombre] || 'group'; // Ícono por defecto si no está mapeado
+  }
 
   exportToExcel(): void {
-    alert('Funcionalidad pendiente');
+    this.exportExcel.emit();
   }
 
   generatePDF(): void {
     alert('Funcionalidad pendiente');
   }
-
 }


### PR DESCRIPTION
Este Pull Request implementa completamente el tablero de Cuerpos Académicos dentro del panel del Coordinador, sustituyendo los datos mockeados por una integración funcional con el backend.
En backend:
Se creó la función PostgreSQL f_conteo_registros_por_cuerpo_academico_por_institucion(p_id_usuario) para obtener:
- Nombre del cuerpo académico
- Total de registros por institución del coordinador
Se agregaron:
- Selector registros_por_cuerpo_academico_selector
- Repositorio para llamada a la función SQL
- Serializer RegistrosPorCuerpoAcademicoSerializer
- Endpoint REST:
- GET /api/tableros/registros/por-cuerpo-academico/
- Endpoint probado satisfactoriamente en Postman.

En frontend:

- Se consume el endpoint desarrollado en el back
- Se eliminaron datos mockeados y se conectaron los tableros con el dashboard de coordinador
- Se mapearon los datos reales con los iconos
- Se probo el tablero satisfactoriamente

<img width="1366" height="720" alt="image" src="https://github.com/user-attachments/assets/842f3c83-53f9-4dc8-a7e1-b57e3da5e76c" />
