### PR TITLE
validaciones de fechas

### DIFF
--- a/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
+++ b/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
@@ -977,6 +977,58 @@ export class ModeloUtilidadComponent implements OnInit, AfterViewInit, OnDestroy
       return;
     }
 
+    // Validación de formato y rango (año >= 2000) y coherencia (solicitud <= expedición)
+    const fechaSolicitudStr = this.indautorModel.fechaSolicitud?.toString() || '';
+    const fechaExpedicionStr = this.indautorModel.fechaExpedicion?.toString() || '';
+
+    const formatos = ['YYYY-MM-DD', 'DD-MM-YYYY', 'YYYY/MM/DD', 'DD/MM/YYYY'];
+    const parseStrict = (val: string): Date | null => {
+      const s = String(val).trim();
+      if (!s) return null;
+      const m = moment(s, formatos, true);
+      return m.isValid() ? m.toDate() : null;
+    };
+
+    if (fechaSolicitudStr) {
+      const solDate = parseStrict(fechaSolicitudStr);
+      if (!solDate || solDate.getFullYear() < 2000) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Fecha de solicitud inválida',
+          text: 'Usa un formato válido (DD-MM-YYYY) y año 2000 o posterior.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
+    if (fechaExpedicionStr) {
+      const expDate = parseStrict(fechaExpedicionStr);
+      if (!expDate || expDate.getFullYear() < 2000) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Fecha de expedición inválida',
+          text: 'Usa un formato válido (DD-MM-YYYY) y año 2000 o posterior.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
+    if (fechaSolicitudStr && fechaExpedicionStr) {
+      const solDate = parseStrict(fechaSolicitudStr)!;
+      const expDate = parseStrict(fechaExpedicionStr)!;
+      if (solDate.getTime() > expDate.getTime()) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Validación de fechas',
+          text: 'Las fechas son inconsistentes: la solicitud debe ser anterior o igual a la expedición.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
     const id = this.indautorModel.id;
     this.isSaving = true;
 

--- a/src/app/pages/comun/propiedad-intelectual/patente/patente.component.ts
+++ b/src/app/pages/comun/propiedad-intelectual/patente/patente.component.ts
@@ -1490,6 +1490,59 @@ export class PatenteComponent implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
 
+    // Validación de fechas: formato válido y año >= 2000; además solicitud <= expedición
+    const fechaSolicitud: string | Date = (this.patenteModel as any).fechaSolicitud;
+    const fechaExpedicion: string | Date = (this.patenteModel as any).fechaExpedicion;
+
+    const formatos = ['YYYY-MM-DD', 'DD-MM-YYYY', 'YYYY/MM/DD', 'DD/MM/YYYY'];
+    const parseStrict = (val: string | Date): Date | null => {
+      if (!val) return null;
+      if (val instanceof Date) return isNaN(val.getTime()) ? null : val;
+      const s = String(val).trim();
+      const m = moment(s, formatos, true);
+      return m.isValid() ? m.toDate() : null;
+    };
+
+    if (fechaSolicitud) {
+      const solDate = parseStrict(fechaSolicitud);
+      if (!solDate || solDate.getFullYear() < 2000) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Fecha de solicitud inválida',
+          text: 'Usa un formato válido (DD-MM-YYYY) y año 2000 o posterior.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
+    if (fechaExpedicion) {
+      const expDate = parseStrict(fechaExpedicion);
+      if (!expDate || expDate.getFullYear() < 2000) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Fecha de expedición inválida',
+          text: 'Usa un formato válido (DD-MM-YYYY) y año 2000 o posterior.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
+    if (fechaSolicitud && fechaExpedicion) {
+      const solDate = parseStrict(fechaSolicitud)!;
+      const expDate = parseStrict(fechaExpedicion)!;
+      if (solDate.getTime() > expDate.getTime()) {
+        const alertaError: SweetAlertOptions = {
+          icon: 'warning',
+          title: 'Validación de fechas',
+          text: 'Las fechas son inconsistentes: la solicitud debe ser anterior o igual a la expedición.',
+        };
+        this.showAlert(alertaError);
+        return;
+      }
+    }
+
     this.isSaving = true;
 
     // 🔹 Si hay un archivo seleccionado, primero lo subimos al servidor


### PR DESCRIPTION
 Validaciones de fechas 
Se agregaron validaciones más estrictas para evitar que se guarden fechas incorrectas o fuera de rango:
• 	Se bloquean años menores a 2000 para evitar fechas basura tipo  o similares.
• 	Se valida que la Fecha de Solicitud no sea mayor que la Fecha de Expedición.
• 	Se agregaron mensajes de error más claros para indicar exactamente qué falló.
