### PR TITLE
Status inconsistency fixed

### DIFF
--- a/src/app/api/services/parametrizaciones.service.ts
+++ b/src/app/api/services/parametrizaciones.service.ts
@@ -27,11 +27,11 @@ export class ParametrizacionesService {
   constructor(private http: HttpClient) {}
 
     private readonly ESTATUS_FALLBACK: { [id: number]: string } = {
-    1: 'Registrada',
+    /**1: 'Registrada',
     2: 'En trámite',
     3: 'Trámite con observaciones',
     4: 'Aprobada',
-    5: 'Concluida',
+    5: 'Concluida',**/
     26: 'Confirmada',
     27: 'Pendiente',
     28: 'Con Observaciones',

--- a/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.html
+++ b/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.html
@@ -304,11 +304,11 @@
         <div class="fv-row col-md-6">
           <label class="fw-semibold fs-6 mb-2 text-gray-600">Estatus</label>
           <select class="form-select" [(ngModel)]="indautorModel.estatus">
-            <option value="Registrada">Registrada</option>
+            <!--<option value="Registrada">Registrada</option>
             <option value="En trámite">En trámite</option>
             <option value="Trámite con observaciones">Trámite con observaciones</option>
             <option value="Aprobada">Aprobada</option>
-            <option value="Concluida">Concluida</option>
+            <option value="Concluida">Concluida</option>-->
             <option value="Confirmada">Confirmada</option>
             <option value="Pendiente">Pendiente</option>
             <option value="Con Observaciones">Con Observaciones</option>

--- a/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
+++ b/src/app/pages/comun/propiedad-intelectual/modelo-utilidad/modelo-utilidad.component.ts
@@ -1071,13 +1071,12 @@ export class ModeloUtilidadComponent implements OnInit, AfterViewInit, OnDestroy
       next: () => {
         this.isSaving = false;
 
-        this.showAlert({
+        const alertaExito: SweetAlertOptions = {
           icon: 'success',
-          title: '¡Guardado!',
-          text: 'Los cambios se guardaron correctamente.',
-          timer: 1800,
-          showConfirmButton: false,
-        });
+          title: 'Registro actualizado',
+          text: 'El modelo de utilidad se actualizó correctamente.',
+        };
+        this.showAlert(alertaExito);
 
         // Limpiar todos los datos de edición
         this.limpiarDatosEdicion();
@@ -1090,11 +1089,12 @@ export class ModeloUtilidadComponent implements OnInit, AfterViewInit, OnDestroy
       },
       error: (err) => {
         this.isSaving = false;
-        this.showAlert({
+        const alertaError: SweetAlertOptions = {
           icon: 'error',
-          title: 'Error al guardar',
-          text: 'Ocurrió un error al guardar los cambios.'
-        });
+          title: 'Error',
+          text: 'Ocurrió un problema al actualizar el modelo de utilidad. Inténtalo de nuevo.',
+        };
+        this.showAlert(alertaError);
         console.error('Error al actualizar registro:', err);
       },
     });

--- a/src/app/pages/comun/propiedad-intelectual/patente/patente.component.html
+++ b/src/app/pages/comun/propiedad-intelectual/patente/patente.component.html
@@ -295,11 +295,11 @@
         <div class="fv-row col-md-6">
           <label class="fw-semibold fs-6 mb-2 text-gray-600">Estatus</label>
           <select class="form-select" [(ngModel)]="patenteModel.estatus">
-            <option value="Registrada">Registrada</option>
+            <!--<option value="Registrada">Registrada</option>
             <option value="En trámite">En trámite</option>
             <option value="Trámite con observaciones">Trámite con observaciones</option>
             <option value="Aprobada">Aprobada</option>
-            <option value="Concluida">Concluida</option>
+            <option value="Concluida">Concluida</option>-->
             <option value="Confirmada">Confirmada</option>
             <option value="Pendiente">Pendiente</option>
             <option value="Con Observaciones">Con Observaciones</option>


### PR DESCRIPTION
# ¿Que se realizó?
Se eliminaron las siguientes opciones de la lista desplegable de estatus al momento de actualizar los registros de IMPI e INDAUTOR en todos los usuarios.
Se homogeneizo la alerta de confirmación de modificación del registro en INDAUTOR para que sea similar a IMPI.

# Evidencias
<img width="468" height="305" alt="image" src="https://github.com/user-attachments/assets/e7c46ba9-bc74-4ac5-b4bb-c4d39b930d9f" />
<img width="468" height="305" alt="image" src="https://github.com/user-attachments/assets/01783cad-2703-48ea-98cc-941b180cdd49" />
<img width="468" height="305" alt="image" src="https://github.com/user-attachments/assets/7683b36d-c505-48b4-9f5b-a3232fcbba2e" />
<img width="468" height="305" alt="image" src="https://github.com/user-attachments/assets/8ef96f29-6ae7-4de8-9320-08ec020cd323" />
